### PR TITLE
Preserve sorting among pinned files.

### DIFF
--- a/src/components/FileView/FileComponent.tsx
+++ b/src/components/FileView/FileComponent.tsx
@@ -144,20 +144,18 @@ export function FileComponent(props: FilesProps) {
                 return true;
             });
         }
-        // Sort File by Name or Last Content Update
+        // Sort File by Name or Last Content Update, moving pinned files to the front
         sortedfileList = sortedfileList.sort((a, b) => {
-            if (plugin.settings.sortFilesBy === 'name') {
+            if (pinnedFiles.contains(a) && !pinnedFiles.contains(b)) {
+                return -1;
+            } else if (!pinnedFiles.contains(a) && pinnedFiles.contains(b)) {
+                return 1;
+            } else if (plugin.settings.sortFilesBy === 'name') {
                 return a.name.localeCompare(b.name, 'en', { numeric: true });
             } else if (plugin.settings.sortFilesBy === 'last-update') {
                 return b.stat.mtime - a.stat.mtime;
             }
         });
-        if (pinnedFiles.length > 0) {
-            sortedfileList = sortedfileList.reduce((acc, element) => {
-                if (pinnedFiles.contains(element)) return [element, ...acc];
-                return [...acc, element];
-            }, []);
-        }
         return sortedfileList;
     };
 


### PR DESCRIPTION
Previously pinned files were moved to the top of the sorted file list by a `reduce` after sorting. This resulted in pinned files being displayed in reverse sorted order.

This modifies the sort comparison function to take pinning into account so that sorting is preserved among pinned files.