### PR TITLE
Vertical layout for Evernote View

### DIFF
--- a/src/components/FileView/FileComponent.tsx
+++ b/src/components/FileView/FileComponent.tsx
@@ -324,7 +324,7 @@ export function FileComponent(props: FilesProps) {
                             <div className={`oz-file-tree-header-wrapper${plugin.settings.fixedHeaderInFileList ? ' file-tree-header-fixed' : ''}`}>
                                 <div className="oz-flex-container">
                                     <div className="oz-nav-action-button" style={{ marginLeft: '0px' }}>
-                                        {plugin.settings.evernoteView ? (
+                                        {['Horizontal', 'Vertical'].includes(plugin.settings.evernoteView) ? (
                                             <Icons.IoIosCloseCircleOutline
                                                 onClick={(e) => handleGoBack(e)}
                                                 size={topIconSize}

--- a/src/components/MainView/MainComponent.tsx
+++ b/src/components/MainView/MainComponent.tsx
@@ -362,10 +362,10 @@ export default function MainTreeComponent(props: MainTreeComponentProps) {
         <React.Fragment>
             {view === 'folder' ? (
                 <MainFolder plugin={plugin} />
-            ) : plugin.settings.evernoteView ? (
-                plugin.settings.evernoteViewHorizontal ? 
-                <SingleViewHorizontal plugin={plugin} /> :
+            ) : plugin.settings.evernoteView === 'Horizontal' ? (
                 <SingleView plugin={plugin} />
+            ) : plugin.settings.evernoteView === 'Vertical' ? (
+                <SingleViewHorizontal plugin={plugin} />
             ) : (
                 <FileComponent plugin={plugin} />
             )}

--- a/src/components/MainView/MainComponent.tsx
+++ b/src/components/MainView/MainComponent.tsx
@@ -2,7 +2,7 @@ import { TAbstractFile, TFile, TFolder, Notice } from 'obsidian';
 import React, { useEffect } from 'react';
 import { FileComponent } from 'components/FileView/FileComponent';
 import { MainFolder } from 'components/FolderView/MainFolder';
-import { SingleView, SingleViewHorizontal } from 'components/MainView/SingleView';
+import { SingleViewVertical, SingleViewHorizontal } from 'components/MainView/SingleView';
 import { FileTreeView } from 'FileTreeView';
 import FileTreeAlternativePlugin, { eventTypes } from 'main';
 import * as FileTreeUtils from 'utils/Utils';
@@ -43,7 +43,7 @@ export default function MainTreeComponent(props: MainTreeComponentProps) {
     };
 
     const setInitialActiveFolderPath = () => {
-        if (plugin.settings.evernoteView) {
+        if (['Horizontal', 'Vertical'].includes(plugin.settings.evernoteView)) {
             let previousActiveFolder = localStorage.getItem(plugin.keys.activeFolderPathKey);
             if (previousActiveFolder) {
                 let folder = plugin.app.vault.getAbstractFileByPath(previousActiveFolder);
@@ -363,9 +363,9 @@ export default function MainTreeComponent(props: MainTreeComponentProps) {
             {view === 'folder' ? (
                 <MainFolder plugin={plugin} />
             ) : plugin.settings.evernoteView === 'Horizontal' ? (
-                <SingleView plugin={plugin} />
-            ) : plugin.settings.evernoteView === 'Vertical' ? (
                 <SingleViewHorizontal plugin={plugin} />
+            ) : plugin.settings.evernoteView === 'Vertical' ? (
+                <SingleViewVertical plugin={plugin} />
             ) : (
                 <FileComponent plugin={plugin} />
             )}

--- a/src/components/MainView/MainComponent.tsx
+++ b/src/components/MainView/MainComponent.tsx
@@ -2,7 +2,7 @@ import { TAbstractFile, TFile, TFolder, Notice } from 'obsidian';
 import React, { useEffect } from 'react';
 import { FileComponent } from 'components/FileView/FileComponent';
 import { MainFolder } from 'components/FolderView/MainFolder';
-import { SingleView } from 'components/MainView/SingleView';
+import { SingleView, SingleViewHorizontal } from 'components/MainView/SingleView';
 import { FileTreeView } from 'FileTreeView';
 import FileTreeAlternativePlugin, { eventTypes } from 'main';
 import * as FileTreeUtils from 'utils/Utils';
@@ -363,6 +363,8 @@ export default function MainTreeComponent(props: MainTreeComponentProps) {
             {view === 'folder' ? (
                 <MainFolder plugin={plugin} />
             ) : plugin.settings.evernoteView ? (
+                plugin.settings.evernoteViewHorizontal ? 
+                <SingleViewHorizontal plugin={plugin} /> :
                 <SingleView plugin={plugin} />
             ) : (
                 <FileComponent plugin={plugin} />

--- a/src/components/MainView/SingleView.tsx
+++ b/src/components/MainView/SingleView.tsx
@@ -3,7 +3,7 @@ import FileTreeAlternativePlugin from 'main';
 import { MainFolder } from 'components/FolderView/MainFolder';
 import { FileComponent } from 'components/FileView/FileComponent';
 
-export const SingleView = (props: { plugin: FileTreeAlternativePlugin }) => {
+export const SingleViewVertical = (props: { plugin: FileTreeAlternativePlugin }) => {
     let { plugin } = props;
 
     const [dividerOnMove, setDividerOnMove] = useState<boolean>(false);

--- a/src/components/MainView/SingleView.tsx
+++ b/src/components/MainView/SingleView.tsx
@@ -66,3 +66,67 @@ export const SingleView = (props: { plugin: FileTreeAlternativePlugin }) => {
         </div>
     );
 };
+
+export const SingleViewHorizontal = (props: { plugin: FileTreeAlternativePlugin }) => {
+    let { plugin } = props;
+
+    const [dividerOnMove, setDividerOnMove] = useState<boolean>(false);
+    const [folderPaneWidth, setFolderPaneWidth] = useState<number>(null);
+    const [clientX, setClientX] = useState<number>(null);
+
+    let folderPaneRef = useRef<HTMLDivElement>();
+    let dividerRef = useRef<HTMLDivElement>();
+
+    let widthSetting = localStorage.getItem(plugin.keys.customWidthKey);
+
+    useEffect(() => {
+        if (folderPaneWidth) {
+            localStorage.setItem(plugin.keys.customWidthKey, folderPaneWidth.toString());
+        }
+    }, [folderPaneWidth]);
+
+    function touchMouseStart(e: React.MouseEvent<HTMLDivElement, MouseEvent>) {
+        e.preventDefault();
+        setDividerOnMove(true);
+        let width = dividerRef.current.offsetLeft - folderPaneRef.current.offsetLeft;
+        setFolderPaneWidth(width);
+        setClientX(e.nativeEvent.clientX);
+    }
+
+    function touchMouseMove(e: React.MouseEvent<HTMLDivElement, MouseEvent>) {
+        e.preventDefault();
+        if (!dividerOnMove) return;
+        setFolderPaneWidth(folderPaneWidth + (e.nativeEvent.clientX - clientX));
+        setClientX(e.nativeEvent.clientX);
+    }
+
+    function touchMouseEnd(e: React.MouseEvent<HTMLDivElement, MouseEvent>) {
+        e.preventDefault();
+        setDividerOnMove(false);
+        setClientX(e.nativeEvent.clientX);
+    }
+
+    return (
+        // Register Move & End Events for All File Tree Leaf
+        <div className="file-tree-container-horizontal" onMouseMove={(e) => touchMouseMove(e)} onMouseUp={(e) => touchMouseEnd(e)}>
+            <div
+                className="oz-folder-pane-horizontal"
+                ref={folderPaneRef}
+                style={{ width: folderPaneWidth ? `${folderPaneWidth}px` : widthSetting && widthSetting !== '' ? `${widthSetting}px` : '50%' }}>
+                <MainFolder plugin={plugin} />
+            </div>
+
+            {/* Mouse Down Event only For Divider */}
+            <div
+                id="file-tree-divider-horizontal"
+                ref={dividerRef}
+                onClick={(e) => e.preventDefault()}
+                onMouseDown={(e) => touchMouseStart(e)}
+                className={dividerOnMove ? 'active-divider' : ''}></div>
+
+            <div className="oz-file-list-pane-horizontal">
+                <FileComponent plugin={plugin} />
+            </div>
+        </div>
+    );
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ export default class FileTreeAlternativePlugin extends Plugin {
         pinnedFilesKey: 'fileTreePlugin-PinnedFiles',
         openFoldersKey: 'fileTreePlugin-OpenFolders',
         customHeightKey: 'fileTreePlugin-CustomHeight',
+        customWidthKey: 'fileTreePlugin-CustomWidth',
         focusedFolder: 'fileTreePlugin-FocusedFolder',
     };
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -22,6 +22,7 @@ export interface FileTreeAlternativePluginSettings {
     folderCount: boolean;
     folderCountOption: string;
     evernoteView: boolean;
+    evernoteViewHorizontal: boolean;
     filePreviewOnHover: boolean;
     iconBeforeFileName: boolean;
     sortFilesBy: SortType;
@@ -49,6 +50,7 @@ export const DEFAULT_SETTINGS: FileTreeAlternativePluginSettings = {
     folderCount: true,
     folderCountOption: 'notes',
     evernoteView: true,
+    evernoteViewHorizontal: false,
     filePreviewOnHover: false,
     iconBeforeFileName: true,
     sortFilesBy: 'name',
@@ -112,6 +114,17 @@ export class FileTreeAlternativePluginSettingsTab extends PluginSettingTab {
             .addToggle((toggle) =>
                 toggle.setValue(this.plugin.settings.evernoteView).onChange((value) => {
                     this.plugin.settings.evernoteView = value;
+                    this.plugin.saveSettings();
+                    this.refreshView();
+                })
+            );
+        
+        new Setting(containerEl)
+            .setName('Evernote View Vertical Layout')
+            .setDesc('Turn on if you want to see the folders and files in Evernote View side-by-side instead of on top of each other.')
+            .addToggle((toggle) =>
+                toggle.setValue(this.plugin.settings.evernoteViewHorizontal).onChange((value) => {
+                    this.plugin.settings.evernoteViewHorizontal = value;
                     this.plugin.saveSettings();
                     this.refreshView();
                 })
@@ -413,6 +426,7 @@ export class FileTreeAlternativePluginSettingsTab extends PluginSettingTab {
                     .setButtonText('Click for Clearing the Cache')
                     .onClick(async () => {
                         lsh.removeFromLocalStorage({ key: this.plugin.keys.customHeightKey });
+                        lsh.removeFromLocalStorage({ key: this.plugin.keys.customWidthKey });
                         lsh.removeFromLocalStorage({ key: this.plugin.keys.openFoldersKey });
                         lsh.removeFromLocalStorage({ key: this.plugin.keys.activeFolderPathKey });
                         lsh.removeFromLocalStorage({ key: this.plugin.keys.focusedFolder });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,7 @@ type FolderIcon = 'default' | 'box-folder' | 'icomoon' | 'typicon' | 'circle-gg'
 export type SortType = 'name' | 'name-rev' | 'last-update' | 'last-update-rev' | 'created' | 'created-rev' | 'file-size' | 'file-size-rev';
 export type FolderSortType = 'name' | 'item-number';
 export type DeleteFileOption = 'trash' | 'permanent' | 'system-trash';
+export type EvernoteViewOption = 'Disabled' | 'Horizontal' | 'Vertical';
 
 export interface FileTreeAlternativePluginSettings {
     openViewOnStart: boolean;
@@ -21,8 +22,7 @@ export interface FileTreeAlternativePluginSettings {
     folderIcon: FolderIcon;
     folderCount: boolean;
     folderCountOption: string;
-    evernoteView: boolean;
-    evernoteViewHorizontal: boolean;
+    evernoteView: EvernoteViewOption;
     filePreviewOnHover: boolean;
     iconBeforeFileName: boolean;
     sortFilesBy: SortType;
@@ -49,8 +49,7 @@ export const DEFAULT_SETTINGS: FileTreeAlternativePluginSettings = {
     folderIcon: 'default',
     folderCount: true,
     folderCountOption: 'notes',
-    evernoteView: true,
-    evernoteViewHorizontal: false,
+    evernoteView: 'Horizontal',
     filePreviewOnHover: false,
     iconBeforeFileName: true,
     sortFilesBy: 'name',
@@ -111,24 +110,18 @@ export class FileTreeAlternativePluginSettingsTab extends PluginSettingTab {
         new Setting(containerEl)
             .setName('Evernote View')
             .setDesc('Turn on if you want to see the folders and files in a single view without switching between views. Similar experience to Evernote.')
-            .addToggle((toggle) =>
-                toggle.setValue(this.plugin.settings.evernoteView).onChange((value) => {
-                    this.plugin.settings.evernoteView = value;
-                    this.plugin.saveSettings();
-                    this.refreshView();
-                })
-            );
-        
-        new Setting(containerEl)
-            .setName('Evernote View Vertical Layout')
-            .setDesc('Turn on if you want to see the folders and files in Evernote View side-by-side instead of on top of each other.')
-            .addToggle((toggle) =>
-                toggle.setValue(this.plugin.settings.evernoteViewHorizontal).onChange((value) => {
-                    this.plugin.settings.evernoteViewHorizontal = value;
-                    this.plugin.saveSettings();
-                    this.refreshView();
-                })
-            );
+            .addDropdown((dropdown) => {
+                dropdown
+                    .addOption('Disabled', 'Disabled')
+                    .addOption('Horizontal', 'Horizontal')
+                    .addOption('Vertical', 'Vertical')
+                    .setValue(this.plugin.settings.evernoteView)
+                    .onChange((value: EvernoteViewOption) => {
+                        this.plugin.settings.evernoteView = value;
+                        this.plugin.saveSettings();
+                        this.refreshView();
+                    });
+            });
 
         new Setting(containerEl)
             .setName('Ribbon Icon')

--- a/styles.css
+++ b/styles.css
@@ -319,10 +319,11 @@ div#file-tree-divider.active-divider {
 }
 
 #file-tree-divider-horizontal {
+    margin-left: 5px;
     width: 3.8px;
     opacity: 0.3;
     cursor: col-resize;
-    margin-right: 5px;
+    margin-right: 3px;
     border-right: 3px solid var(--text-muted);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -296,6 +296,45 @@ div#file-tree-divider.active-divider {
     background-color: var(--text-muted);
 }
 
+.file-tree-container-horizontal {
+    display: flex;
+    flex-direction: row;
+    height: 100%;
+    max-width: 100%;
+}
+
+.oz-folder-pane-horizontal {
+    display: block;
+    width: 50%;
+    overflow-y: auto;
+    height: 100%;
+    resize: horizontal;
+}
+
+.oz-file-list-pane-horizontal {
+    display: block;
+    height: 100%;
+    overflow-y: auto;
+    flex: 1;
+}
+
+#file-tree-divider-horizontal {
+    width: 3.8px;
+    opacity: 0.3;
+    cursor: col-resize;
+    margin-right: 5px;
+    border-right: 3px solid var(--text-muted);
+}
+
+div#file-tree-divider-horizontal.active-divider {
+    background-color: var(--interactive-accent);
+    border-bottom: 0.5px solid var(--interactive-accent);
+}
+
+#file-tree-divider-horizontal:hover {
+    background-color: var(--text-muted);
+}
+
 .is-folder-active {
     color: var(--text-normal);
     font-weight: bold;


### PR DESCRIPTION
I added an option to have a vertical layout (directory and file panes side-by-side) in the Evernote view. the option is disabled by default.

This feature has been requested already in #90 and #95.
This is also one of the features I'm missing from Evernote, where I could see all the folders at a glance without scrolling.
For large screens and short folder names there is enough space to nicely fit the panes (see screenshot).

![image](https://user-images.githubusercontent.com/903651/211927867-fb680e5e-687a-4af5-b6f8-c6c753e8d07c.png)
