### PR TITLE
Reverse current file order and add checkmarks on the menu

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,6 @@
     "description": "This plugin allows you to have an alternative file tree view.",
     "author": "Ozan Tellioglu",
     "authorUrl": "https://www.ozan.pl",
+    "fundingUrl": "https://ko-fi.com/ozante",
     "isDesktopOnly": false
 }

--- a/src/components/FileView/FileComponent.tsx
+++ b/src/components/FileView/FileComponent.tsx
@@ -111,8 +111,7 @@ export function FileComponent(props: FilesProps) {
 
     const filesToList: TFile[] = useMemo(
         () => customFiles(fileList),
-        [excludedFolders, excludedExtensions, pinnedFiles, fileList,
-            plugin.settings.sortFilesBy, plugin.settings.sortReverse]
+        [excludedFolders, excludedExtensions, pinnedFiles, fileList, plugin.settings.sortFilesBy, plugin.settings.sortReverse]
     );
 
     // Go Back Button - Sets Main Component View to Folder
@@ -235,11 +234,11 @@ export function FileComponent(props: FilesProps) {
             sortMenu.addItem((menuItem) => {
                 const order = plugin.settings.sortReverse ? `${high} to ${low}` : `${low} to ${high}`;
                 menuItem.setTitle(`${label} (${order})`);
-                menuItem.setIcon(value === plugin.settings.sortFilesBy ? 'checkmark' : 'space');
+                menuItem.setIcon(value === plugin.settings.sortFilesBy ? 'checkmark' : 'spaceIcon');
                 menuItem.onClick(() => changeSortSettingTo(value));
             });
         };
-        
+
         addMenuItem('File Name', 'A', 'Z', 'name');
         addMenuItem('Created', 'New', 'Old', 'created');
         addMenuItem('File Size', 'Big', 'Small', 'file-size');
@@ -249,7 +248,7 @@ export function FileComponent(props: FilesProps) {
 
         sortMenu.addItem((menuItem) => {
             menuItem.setTitle('Reverse Order');
-            menuItem.setIcon(plugin.settings.sortReverse ? 'checkmark' : 'space');
+            menuItem.setIcon(plugin.settings.sortReverse ? 'checkmark' : 'spaceIcon');
             menuItem.onClick(() => {
                 plugin.settings.sortReverse = !plugin.settings.sortReverse;
                 plugin.saveSettings();
@@ -258,9 +257,7 @@ export function FileComponent(props: FilesProps) {
         });
 
         // Trigger
-        plugin.app.workspace.trigger('sort-menu', sortMenu);
         sortMenu.showAtPosition({ x: e.pageX, y: e.pageY });
-        return false;
     };
 
     const topIconSize = 19;

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,8 @@ export default class FileTreeAlternativePlugin extends Plugin {
         addIcon('zoomOutIcon', ZoomOutIcon);
         addIcon('zoomOutDoubleIcon', ZoomOutDoubleIcon);
         addIcon('locationIcon', LocationIcon);
+        // blank icon for padding
+        addIcon("space", `<circle cx="50" cy="50" r="50" fill="transparent" />`);
 
         // Load Settings
         this.addSettingTab(new FileTreeAlternativePluginSettingsTab(this.app, this));

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { Plugin, addIcon, TAbstractFile } from 'obsidian';
 import { VIEW_TYPE, FileTreeView, ICON } from './FileTreeView';
-import { ZoomInIcon, ZoomOutIcon, ZoomOutDoubleIcon, LocationIcon } from './utils/icons';
+import { ZoomInIcon, ZoomOutIcon, ZoomOutDoubleIcon, LocationIcon, SpaceIcon } from './utils/icons';
 import { FileTreeAlternativePluginSettings, FileTreeAlternativePluginSettingsTab, DEFAULT_SETTINGS } from './settings';
 import { VaultChange } from 'utils/types';
 
@@ -30,8 +30,7 @@ export default class FileTreeAlternativePlugin extends Plugin {
         addIcon('zoomOutIcon', ZoomOutIcon);
         addIcon('zoomOutDoubleIcon', ZoomOutDoubleIcon);
         addIcon('locationIcon', LocationIcon);
-        // blank icon for padding
-        addIcon("space", `<circle cx="50" cy="50" r="50" fill="transparent" />`);
+        addIcon('spaceIcon', SpaceIcon);
 
         // Load Settings
         this.addSettingTab(new FileTreeAlternativePluginSettingsTab(this.app, this));

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,7 +3,7 @@ import { PluginSettingTab, Setting, App, Notice } from 'obsidian';
 import { LocalStorageHandler } from '@ozntel/local-storage-handler';
 
 type FolderIcon = 'default' | 'box-folder' | 'icomoon' | 'typicon' | 'circle-gg';
-export type SortType = 'name' | 'name-rev' | 'last-update' | 'last-update-rev' | 'created' | 'created-rev' | 'file-size' | 'file-size-rev';
+export type SortType = 'name' | 'last-update' | 'created' | 'file-size';
 export type FolderSortType = 'name' | 'item-number';
 export type DeleteFileOption = 'trash' | 'permanent' | 'system-trash';
 
@@ -25,6 +25,7 @@ export interface FileTreeAlternativePluginSettings {
     filePreviewOnHover: boolean;
     iconBeforeFileName: boolean;
     sortFilesBy: SortType;
+    sortReverse: boolean;
     sortFoldersBy: FolderSortType;
     fixedHeaderInFileList: boolean;
     createdYaml: boolean;
@@ -52,6 +53,7 @@ export const DEFAULT_SETTINGS: FileTreeAlternativePluginSettings = {
     filePreviewOnHover: false,
     iconBeforeFileName: true,
     sortFilesBy: 'name',
+    sortReverse: false,
     sortFoldersBy: 'name',
     fixedHeaderInFileList: true,
     createdYaml: false,

--- a/src/utils/icons.tsx
+++ b/src/utils/icons.tsx
@@ -59,6 +59,7 @@ const LocationIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height
 const ZoomOutIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line><line x1="8" y1="11" x2="14" y2="11"></line></svg>`;
 const ZoomOutDoubleIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 50 50" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M 21 3 C 11.621094 3 4 10.621094 4 20 C 4 29.378906 11.621094 37 21 37 C 24.710938 37 28.140625 35.804688 30.9375 33.78125 L 44.09375 46.90625 L 46.90625 44.09375 L 33.90625 31.0625 C 36.460938 28.085938 38 24.222656 38 20 C 38 10.621094 30.378906 3 21 3 Z M 21 5 C 29.296875 5 36 11.703125 36 20 C 36 28.296875 29.296875 35 21 35 C 12.703125 35 6 28.296875 6 20 C 6 11.703125 12.703125 5 21 5 Z M 13 12 L 13 18 L 15.28125 15.71875 L 19.5625 20 L 15.28125 24.28125 L 13 22 L 13 28 L 19 28 L 16.71875 25.71875 L 21 21.4375 L 25.28125 25.71875 L 23 28 L 29 28 L 29 22 L 26.71875 24.28125 L 22.4375 20 L 26.71875 15.71875 L 29 18 L 29 12 L 23 12 L 25.28125 14.28125 L 21 18.5625 L 16.71875 14.28125 L 19 12 Z"/></svg>`;
 const ZoomInIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line><line x1="11" y1="8" x2="11" y2="14"></line><line x1="8" y1="11" x2="14" y2="11"></line></svg>`;
+const SpaceIcon = `<circle cx="50" cy="50" r="50" fill="transparent" />`;
 
 export const getFolderIcon = (plugin: FileTreeAlternativePlugin, children: boolean, open: boolean) => {
     let setting = plugin.settings.folderIcon;
@@ -98,6 +99,7 @@ export {
     ZoomOutIcon,
     ZoomInIcon,
     ZoomOutDoubleIcon,
+    SpaceIcon,
     IoIosSearch,
     IoIosEye,
     IoIosEyeOff,


### PR DESCRIPTION
In the file view I merged the sorting options that differ only by the direction of sorting, e.g., *File Name (A to Z)* and *File Name (Z to A)*. Following Evernote's strategy, I added a *Reverse Order* option to switch between the two.

To reduce confusion, I also added the following features:
* a checkmark indicates the selected sorting option, and if the reverse order is active (see screenshot)
* checking *Reverse Order* changes the labels to reflect the current sorting option, so you don't need to remember which one is the default

![image](https://user-images.githubusercontent.com/903651/211931305-f3e7ffa0-37cc-4be8-84b9-b14cddb71620.png)
