### PR TITLE
Add excluded attach folder setting for folder display

### DIFF
--- a/src/components/FolderView/NestedFolders.tsx
+++ b/src/components/FolderView/NestedFolders.tsx
@@ -224,7 +224,7 @@ export function NestedFolders(props: NestedFoldersProps) {
                 sortedFolderTree.map((child) => {
                     return (
                         <React.Fragment key={child.folder.path}>
-                            {(child.folder as TFolder).children.some((child) => child instanceof TFolder) ? (
+                            {(child.folder as TFolder).children.some((child) => child instanceof TFolder && child.name !== plugin.settings.excludedAttachFolder) ? (
                                 <Tree
                                     plugin={plugin}
                                     content={child.folder.name}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -35,6 +35,7 @@ export interface FileTreeAlternativePluginSettings {
     folderNote: boolean;
     deleteFileOption: DeleteFileOption;
     showFileNameAsFullPath: boolean;
+    excludedAttachFolder: string;
 }
 
 export const DEFAULT_SETTINGS: FileTreeAlternativePluginSettings = {
@@ -48,6 +49,7 @@ export const DEFAULT_SETTINGS: FileTreeAlternativePluginSettings = {
     revealActiveFileButton: false,
     excludedExtensions: '',
     excludedFolders: '',
+    excludedAttachFolder: 'images',
     folderIcon: 'default',
     folderCount: true,
     folderCountOption: 'notes',
@@ -389,6 +391,18 @@ export class FileTreeAlternativePluginSettingsTab extends PluginSettingTab {
             .addTextArea((text) =>
                 text.setValue(this.plugin.settings.excludedFolders).onChange((value) => {
                     this.plugin.settings.excludedFolders = value;
+                    this.plugin.saveSettings();
+                })
+            );
+
+        new Setting(containerEl)
+            .setName('Excluded Attachment Folder')
+            .setDesc(
+                `Provide attachment folder name, which you want to exclude from the folder being displayed as nested folder`
+            )
+            .addTextArea((text) =>
+                text.setValue(this.plugin.settings.excludedAttachFolder).onChange((value) => {
+                    this.plugin.settings.excludedAttachFolder = value;
                     this.plugin.saveSettings();
                 })
             );


### PR DESCRIPTION
Hi,
This patch helps properly shows the folder with attachment subfolders as a normal folder rather than nested folder.

Thanks,
Houcheng