### PR TITLE
Add file order plugin support

### DIFF
--- a/src/components/FileView/FileComponent.tsx
+++ b/src/components/FileView/FileComponent.tsx
@@ -573,7 +573,8 @@ const NavFile = (props: { file: TFile; plugin: FileTreeAlternativePlugin }) => {
 
     const fileDisplayName = useMemo(() => {
         let displayName = plugin.settings.showFileNameAsFullPath ? file.path : file.name;
-        return Util.getFileNameAndExtension(displayName).fileName;
+        let displayFileName = Util.getFileNameAndExtension(displayName).fileName;
+        return plugin.settings.hideFileOrderNumber ? displayFileName.replace(/^\d{1,4}[- ]/, '') : displayFileName;
     }, [plugin.settings.showFileNameAsFullPath, file.path]);
 
     return (

--- a/src/components/FolderView/NestedFolders.tsx
+++ b/src/components/FolderView/NestedFolders.tsx
@@ -218,6 +218,10 @@ export function NestedFolders(props: NestedFoldersProps) {
         [props.folderTree.children, excludedFolders, plugin.settings.sortFoldersBy]
     );
 
+    let getFolderName = (folder: TFolder) => {
+        return plugin.settings.hideFileOrderNumber ? folder.name.replace(/^\d{1,4}[- ]/, '') : folder.name;
+    }
+
     return (
         <React.Fragment>
             {Array.isArray(props.folderTree.children) &&
@@ -227,7 +231,7 @@ export function NestedFolders(props: NestedFoldersProps) {
                             {(child.folder as TFolder).children.some((child) => child instanceof TFolder) ? (
                                 <Tree
                                     plugin={plugin}
-                                    content={child.folder.name}
+                                    content={getFolderName(child.folder)}
                                     open={openFolders.contains(child.folder.path)}
                                     onClick={() => handleFolderNameClick(child.folder.path)}
                                     onDoubleClick={() => handleFolderNameDoubleClick(child.folder)}
@@ -243,7 +247,7 @@ export function NestedFolders(props: NestedFoldersProps) {
                             ) : (
                                 <Tree
                                     plugin={plugin}
-                                    content={child.folder.name}
+                                    content={getFolderName(child.folder)}
                                     onClick={() => handleFolderNameClick(child.folder.path)}
                                     onDoubleClick={() => handleFolderNameDoubleClick(child.folder)}
                                     onContextMenu={(e: MouseEvent) =>

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -35,6 +35,7 @@ export interface FileTreeAlternativePluginSettings {
     folderNote: boolean;
     deleteFileOption: DeleteFileOption;
     showFileNameAsFullPath: boolean;
+    hideFileOrderNumber: boolean;
 }
 
 export const DEFAULT_SETTINGS: FileTreeAlternativePluginSettings = {
@@ -63,6 +64,7 @@ export const DEFAULT_SETTINGS: FileTreeAlternativePluginSettings = {
     folderNote: false,
     deleteFileOption: 'trash',
     showFileNameAsFullPath: false,
+    hideFileOrderNumber: false,
 };
 
 export class FileTreeAlternativePluginSettingsTab extends PluginSettingTab {
@@ -389,6 +391,16 @@ export class FileTreeAlternativePluginSettingsTab extends PluginSettingTab {
             .addTextArea((text) =>
                 text.setValue(this.plugin.settings.excludedFolders).onChange((value) => {
                     this.plugin.settings.excludedFolders = value;
+                    this.plugin.saveSettings();
+                })
+            );
+
+        new Setting(containerEl)
+            .setName('Hide File Order Number')
+            .setDesc('Turn on if you want to hide numbers of file order plugin.')
+            .addToggle((toggle) =>
+                toggle.setValue(this.plugin.settings.hideFileOrderNumber).onChange((value) => {
+                    this.plugin.settings.hideFileOrderNumber = value;
                     this.plugin.saveSettings();
                 })
             );


### PR DESCRIPTION
Add file order plugin support that hides the starting digits of file and folder names.
By default and for the simplicify of setting, this feature assumes user use the '-' or ' ' as delimiter.
